### PR TITLE
Let `put` and `delete` receive `**kwargs`

### DIFF
--- a/plugins/module_utils/gcp_utils.py
+++ b/plugins/module_utils/gcp_utils.py
@@ -102,14 +102,14 @@ class GcpSession(object):
         kwargs.update({'data': file_contents, 'headers': headers})
         return self.full_post(url, **kwargs)
 
-    def delete(self, url, body=None):
+    def delete(self, url, body=None, **kwargs):
         """
         This method should be avoided in favor of full_delete
         """
         kwargs = {'json': body}
         return self.full_delete(url, **kwargs)
 
-    def put(self, url, body=None):
+    def put(self, url, body=None, **kwargs):
         """
         This method should be avoided in favor of full_put
         """


### PR DESCRIPTION
There was a bug in this library from 2019 that nobody has bothered to
fix.

We now fix it.